### PR TITLE
Add plotly.js and @plotly organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ These projects have been developed mainly in Montréal, or by Montréalers.
 
 - [AmpMe](https://github.com/AmpMe) - Sync your phone with friends to create the world's most portable sound system. [Website](http://ampme.com/).
 - [Parse](https://github.com/parseplatform) - [Website](https://parseplatform.github.io).
+- [plotly.js](https://github.com/plotly/plotly.js) - Javascript graphing library
 - [Prince of Persia Apple II](https://github.com/jmechner/Prince-of-Persia-Apple-II) - A running-jumping-swordfighting game I made on the Apple II from 1985-89. [Website](http://jordanmechner.com/ebook).
 - [SVProgressHUD](https://github.com/SVProgressHUD) - A clean and lightweight progress HUD for your iOS and tvOS app.
 
@@ -26,6 +27,7 @@ These projects have been developed mainly in Montréal, or by Montréalers.
 - [@BetterMTL](https://github.com/bettermtl) - Data layered to engage city-wide activities and teams. [Website]( http://bettermtl.com).
 - [@busbud](https://github.com/busbud) [Website](https://www.busbud.com/).
 - [@MeteorMTL](https://github.com/MeteorMTL)
+- [@plotly](https://github.com/plotly) - A data visualization company. [Website](https://plot.ly)
 - [@TransitApp](https://github.com/transitapp) - A commuter helping company. [Website](https://transitapp.com/).
 - [@wet-boew](https://github.com/wet-boew) - Web Experience Toolkit (WET): Open source code library for building innovative websites that are accessible, usable, interoperable, mobile-friendly and multilingual. This collaborative open source project is led by the Government of Canada.
 


### PR DESCRIPTION
Thanks for compiling! Great list so far. This PR adds [plotly](https://plot.ly) and our flagship open source project, [plotly.js](https://github.com/plotly/plotly.js)

🍻  Cheers!

Chris